### PR TITLE
Add Spring Boot backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 node_modules/
 dist/
 unpackage/
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.dada.codex'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+bootJar {
+    archiveFileName = 'backend.jar'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'backend'

--- a/src/main/java/com/dada/codex/DadaCodexApplication.java
+++ b/src/main/java/com/dada/codex/DadaCodexApplication.java
@@ -1,0 +1,11 @@
+package com.dada.codex;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DadaCodexApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DadaCodexApplication.class, args);
+    }
+}

--- a/src/main/java/com/dada/codex/web/HelloController.java
+++ b/src/main/java/com/dada/codex/web/HelloController.java
@@ -1,0 +1,13 @@
+package com.dada.codex.web;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    @GetMapping("/api/hello")
+    public Map<String, String> hello() {
+        return Map.of("msg", "hello codex");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080


### PR DESCRIPTION
## Summary
- Initialize Gradle-based Spring Boot 3 project `backend`
- Add HelloController with `/api/hello` endpoint
- Configure application to run on port 8080

## Testing
- `gradle build` *(fails: Plugin [id: 'org.springframework.boot', version: '3.2.5'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a861001b908320a136d94ba22fe68d