### PR TITLE
Add user pagination API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/dada/codex/user/User.java
+++ b/src/main/java/com/dada/codex/user/User.java
@@ -1,0 +1,54 @@
+package com.dada.codex.user;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String phone;
+
+    private String nickname;
+
+    @Column(name = "create_time")
+    private LocalDateTime createTime;
+
+    public User() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/src/main/java/com/dada/codex/user/UserController.java
+++ b/src/main/java/com/dada/codex/user/UserController.java
@@ -1,0 +1,20 @@
+package com.dada.codex.user;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/api/user/list")
+    public UserPageResponse list(@RequestParam(defaultValue = "1") int page,
+                                 @RequestParam(defaultValue = "10") int size) {
+        return userService.listUsers(page, size);
+    }
+}

--- a/src/main/java/com/dada/codex/user/UserDto.java
+++ b/src/main/java/com/dada/codex/user/UserDto.java
@@ -1,0 +1,9 @@
+package com.dada.codex.user;
+
+import java.time.LocalDateTime;
+
+public record UserDto(Long id, String phone, String nickname, LocalDateTime createTime) {
+    public static UserDto fromEntity(User user) {
+        return new UserDto(user.getId(), user.getPhone(), user.getNickname(), user.getCreateTime());
+    }
+}

--- a/src/main/java/com/dada/codex/user/UserPageResponse.java
+++ b/src/main/java/com/dada/codex/user/UserPageResponse.java
@@ -1,0 +1,6 @@
+package com.dada.codex.user;
+
+import java.util.List;
+
+public record UserPageResponse(long total, int page, List<UserDto> list) {
+}

--- a/src/main/java/com/dada/codex/user/UserRepository.java
+++ b/src/main/java/com/dada/codex/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.dada.codex.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/dada/codex/user/UserService.java
+++ b/src/main/java/com/dada/codex/user/UserService.java
@@ -1,0 +1,21 @@
+package com.dada.codex.user;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserPageResponse listUsers(int page, int size) {
+        Page<User> result = userRepository.findAll(PageRequest.of(page - 1, size));
+        List<UserDto> list = result.getContent().stream().map(UserDto::fromEntity).toList();
+        return new UserPageResponse(result.getTotalElements(), page, list);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,11 @@
 server:
   port: 8080
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/your_db
+    username: your_username
+    password: your_password
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,6 @@
+create table if not exists user (
+    id bigint primary key auto_increment,
+    phone varchar(20) not null,
+    nickname varchar(50),
+    create_time datetime not null
+);


### PR DESCRIPTION
## Summary
- add JPA entity, repository, service, and controller to list users with pagination
- configure datasource and JPA settings and provide schema.sql

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.2.5'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a862f9ab888320bc7977268a369b6f