### PR TITLE
feat: add user list search and sorting

### DIFF
--- a/src/main/java/com/dada/codex/user/UserController.java
+++ b/src/main/java/com/dada/codex/user/UserController.java
@@ -14,7 +14,10 @@ public class UserController {
 
     @GetMapping("/api/user/list")
     public UserPageResponse list(@RequestParam(defaultValue = "1") int page,
-                                 @RequestParam(defaultValue = "10") int size) {
-        return userService.listUsers(page, size);
+                                 @RequestParam(defaultValue = "10") int size,
+                                 @RequestParam(required = false) String kw,
+                                 @RequestParam(defaultValue = "createTime") String sortBy,
+                                 @RequestParam(defaultValue = "desc") String order) {
+        return userService.listUsers(page, size, kw, sortBy, order);
     }
 }

--- a/src/main/java/com/dada/codex/user/UserPageResponse.java
+++ b/src/main/java/com/dada/codex/user/UserPageResponse.java
@@ -2,5 +2,5 @@ package com.dada.codex.user;
 
 import java.util.List;
 
-public record UserPageResponse(long total, int page, List<UserDto> list) {
+public record UserPageResponse(long total, int page, int size, List<UserDto> data) {
 }

--- a/src/main/java/com/dada/codex/user/UserRepository.java
+++ b/src/main/java/com/dada/codex/user/UserRepository.java
@@ -1,6 +1,11 @@
 package com.dada.codex.user;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Page<User> findByPhoneContainingIgnoreCaseOrNicknameContainingIgnoreCase(String phone,
+                                                                            String nickname,
+                                                                            Pageable pageable);
 }

--- a/src/main/java/com/dada/codex/user/UserService.java
+++ b/src/main/java/com/dada/codex/user/UserService.java
@@ -3,6 +3,7 @@ package com.dada.codex.user;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,9 +14,18 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public UserPageResponse listUsers(int page, int size) {
-        Page<User> result = userRepository.findAll(PageRequest.of(page - 1, size));
+    public UserPageResponse listUsers(int page, int size, String kw, String sortBy, String order) {
+        String sortProperty = "id".equalsIgnoreCase(sortBy) ? "id" : "createTime";
+        Sort.Direction direction = "asc".equalsIgnoreCase(order) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        PageRequest request = PageRequest.of(page - 1, size, Sort.by(direction, sortProperty));
+        Page<User> result;
+        if (kw != null && !kw.isBlank()) {
+            result = userRepository
+                .findByPhoneContainingIgnoreCaseOrNicknameContainingIgnoreCase(kw, kw, request);
+        } else {
+            result = userRepository.findAll(request);
+        }
         List<UserDto> list = result.getContent().stream().map(UserDto::fromEntity).toList();
-        return new UserPageResponse(result.getTotalElements(), page, list);
+        return new UserPageResponse(result.getTotalElements(), page, size, list);
     }
 }


### PR DESCRIPTION
## Summary
- support keyword search on user phone or nickname
- allow sorting by id or creation time with order
- include page size and data list in user page response

## Testing
- `gradle build -x test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.2.5'] was not found)*
- `curl -sS localhost:8080/api/user/list` *(connection refused; app not running)*

------
https://chatgpt.com/codex/tasks/task_e_68a928cc883c8320861f4ae2dab0d8bd