### PR TITLE
Add minimal UniApp Vue3 frontend

### DIFF
--- a/frontend-uniapp/.gitignore
+++ b/frontend-uniapp/.gitignore
@@ -1,0 +1,3 @@
+unpackage/
+dist/
+node_modules/

--- a/frontend-uniapp/App.vue
+++ b/frontend-uniapp/App.vue
@@ -1,0 +1,16 @@
+<template>
+  <slot />
+</template>
+
+<script>
+export default {
+  onLaunch() {
+    this.globalData = this.globalData || {};
+    this.globalData.BASE_URL = 'http://localhost:8080';
+  }
+};
+</script>
+
+<style>
+/* global styles */
+</style>

--- a/frontend-uniapp/api/user.js
+++ b/frontend-uniapp/api/user.js
@@ -1,0 +1,9 @@
+import request from '@/utils/request.js';
+
+export function fetchUserPage({ page, size, kw }) {
+  return request({
+    url: '/api/user/list',
+    method: 'GET',
+    data: { page, size, kw }
+  });
+}

--- a/frontend-uniapp/components/header/TitleBar.vue
+++ b/frontend-uniapp/components/header/TitleBar.vue
@@ -1,0 +1,25 @@
+<template>
+  <view class="title-bar">
+    <text class="title">{{ title }}</text>
+  </view>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    default: ''
+  }
+});
+</script>
+
+<style>
+.title-bar {
+  padding: 16rpx;
+  background-color: #f8f8f8;
+}
+.title {
+  font-size: 32rpx;
+  font-weight: bold;
+}
+</style>

--- a/frontend-uniapp/main.js
+++ b/frontend-uniapp/main.js
@@ -1,0 +1,9 @@
+import { createSSRApp } from 'vue';
+import App from './App.vue';
+
+export function createApp() {
+  const app = createSSRApp(App);
+  return {
+    app
+  };
+}

--- a/frontend-uniapp/manifest.json
+++ b/frontend-uniapp/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Frontend UniApp",
+  "appid": "__UNI__DEMO",
+  "description": "Minimal UniApp Vue3 app",
+  "versionName": "1.0.0",
+  "versionCode": "100",
+  "uni-app": {
+    "compilerVersion": "3.0.0"
+  },
+  "launch_path": "pages/user/index",
+  "h5": {
+    "title": "Frontend UniApp"
+  }
+}

--- a/frontend-uniapp/pages.json
+++ b/frontend-uniapp/pages.json
@@ -1,0 +1,10 @@
+{
+  "pages": [
+    {
+      "path": "pages/user/index",
+      "style": {
+        "navigationBarTitleText": "Users"
+      }
+    }
+  ]
+}

--- a/frontend-uniapp/pages/user/index.vue
+++ b/frontend-uniapp/pages/user/index.vue
@@ -1,0 +1,113 @@
+<template>
+  <view class="page">
+    <TitleBar title="Users" />
+    <view class="search-bar">
+      <input v-model="kw" placeholder="Search users" @confirm="onSearch" />
+      <button @click="onSearch">Search</button>
+    </view>
+    <scroll-view
+      class="list"
+      scroll-y
+      :refresher-enabled="true"
+      :refresher-triggered="refreshing"
+      @refresherrefresh="onRefresh"
+      @scrolltolower="loadMore"
+    >
+      <view v-for="user in users" :key="user.id" class="item">{{ user.name }}</view>
+      <view v-if="loading" class="loading">Loading...</view>
+      <view v-if="finished" class="finished">No more</view>
+    </scroll-view>
+  </view>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import TitleBar from '@/components/header/TitleBar.vue';
+import { fetchUserPage } from '@/api/user.js';
+
+const kw = ref('');
+const page = ref(1);
+const size = 20;
+const users = ref([]);
+const loading = ref(false);
+const finished = ref(false);
+const refreshing = ref(false);
+
+const load = async (reset = false) => {
+  if (loading.value || (finished.value && !reset)) {
+    return;
+  }
+  loading.value = true;
+  const data = await fetchUserPage({ page: page.value, size, kw: kw.value });
+  const list = data?.data || data?.list || data || [];
+  if (reset) {
+    users.value = list;
+  } else {
+    users.value = users.value.concat(list);
+  }
+  if (!list || list.length < size) {
+    finished.value = true;
+  } else {
+    finished.value = false;
+  }
+  loading.value = false;
+};
+
+const onSearch = () => {
+  page.value = 1;
+  finished.value = false;
+  load(true);
+};
+
+const loadMore = () => {
+  if (!finished.value) {
+    page.value += 1;
+    load();
+  }
+};
+
+const onRefresh = async () => {
+  refreshing.value = true;
+  page.value = 1;
+  finished.value = false;
+  await load(true);
+  refreshing.value = false;
+};
+
+onMounted(() => {
+  load(true);
+});
+</script>
+
+<style>
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+.search-bar {
+  display: flex;
+  padding: 10rpx;
+}
+.search-bar input {
+  flex: 1;
+  border: 1px solid #ccc;
+  padding: 8rpx;
+}
+.search-bar button {
+  margin-left: 8rpx;
+}
+.list {
+  flex: 1;
+}
+.item {
+  padding: 16rpx;
+  border-bottom: 1px solid #eee;
+}
+.loading,
+.finished {
+  text-align: center;
+  padding: 16rpx;
+  color: #999;
+}
+</style>

--- a/frontend-uniapp/utils/request.js
+++ b/frontend-uniapp/utils/request.js
@@ -1,0 +1,13 @@
+export default function request(options) {
+  const app = getApp();
+  const baseUrl = app?.globalData?.BASE_URL || '';
+  return new Promise((resolve, reject) => {
+    uni.request({
+      url: baseUrl + options.url,
+      method: options.method || 'GET',
+      data: options.data || {},
+      success: (res) => resolve(res.data),
+      fail: reject
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold frontend-uniapp with UniApp + Vue3
- add user page with search, pull-to-refresh and infinite scroll
- provide request utility and user API wrapper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a928ea52a4832096823084f5c4e383