### PR TITLE
chore(frontend): set BASE_URL only in development

### DIFF
--- a/frontend-uniapp/App.vue
+++ b/frontend-uniapp/App.vue
@@ -6,7 +6,9 @@
 export default {
   onLaunch() {
     this.globalData = this.globalData || {};
-    this.globalData.BASE_URL = 'http://localhost:8080';
+    if (process.env.NODE_ENV === 'development') {
+      this.globalData.BASE_URL = 'http://localhost:8080';
+    }
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- set `BASE_URL` only when running in development mode

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a92caabce0832086329612cf916cb6