### PR TITLE
fix(frontend): remove slot root from App.vue

### DIFF
--- a/frontend-uniapp/App.vue
+++ b/frontend-uniapp/App.vue
@@ -1,7 +1,3 @@
-<template>
-  <slot />
-</template>
-
 <script>
 export default {
   onLaunch() {


### PR DESCRIPTION
## Summary
- fix compile error by removing `<slot>` root from App.vue

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9335bca948320b6390e5b6b0738d8